### PR TITLE
Update dependencies. Fixes build fail with section_title_tags

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==4.3.0
+Sphinx==4.3.2
 sphinx-rtd-theme==1.0.0
 sphinx-autobuild==2021.3.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==3.3.1
-sphinx-rtd-theme==0.5.0
-sphinx-autobuild==2020.9.1
+Sphinx==4.3.0
+sphinx-rtd-theme==1.0.0
+sphinx-autobuild==2021.3.14


### PR DESCRIPTION
This fixes an issue which causes the build to fail with the error
`AttributeError: 'Values' object has no attribute 'section_self_link'`

The issue was mentioned in sphinx-doc/sphinx#9825. Updating Sphinx to 4.3.0 fixes the build error.